### PR TITLE
php_ldap fix for php7.0

### DIFF
--- a/docker/shared_steps/install_php_extensions.sh
+++ b/docker/shared_steps/install_php_extensions.sh
@@ -11,14 +11,13 @@ php_install_gd() {
 }
 
 php_install_ldap() {
-  local php=$(which php)
-  local php_version=$($php --version | head -n1 | cut -d " " -f 2 | cut -d . -f 1,2)
+  local php_version=$($PHP --version | head -n1 | cut -d " " -f 2 | cut -d . -f 1,2)
   if [ $php_version = "7.0" ]; then
-    install_packages "libldb-dev"
+    install_packages --build "libldb-dev"
     ln -s /usr/lib/x86_64-linux-gnu/libldap.so /usr/lib/libldap.so
   fi
-    sectionText "Use core install"
-    eatmydata docker-php-ext-install -j$COMPILE_JOBS $ext &>> $BUILD_LOG
+  sectionText "Use core install"
+  eatmydata docker-php-ext-install -j$COMPILE_JOBS $ext &>> $BUILD_LOG
 }
 
 php_install_extensions() {

--- a/docker/shared_steps/install_php_extensions.sh
+++ b/docker/shared_steps/install_php_extensions.sh
@@ -10,6 +10,17 @@ php_install_gd() {
   eatmydata docker-php-ext-install -j$COMPILE_JOBS $ext
 }
 
+php_install_ldap() {
+  local php=$(which php)
+  local php_version=$($php --version | head -n1 | cut -d " " -f 2 | cut -d . -f 1,2)
+  if [ $php_version = "7.0" ]; then
+    install_packages "libldb-dev"
+    ln -s /usr/lib/x86_64-linux-gnu/libldap.so /usr/lib/libldap.so
+  fi
+    sectionText "Use core install"
+    eatmydata docker-php-ext-install -j$COMPILE_JOBS $ext &>> $BUILD_LOG
+}
+
 php_install_extensions() {
   local extensions="$*"
   install_packages --build $PHP_BUILD_PACKAGES


### PR DESCRIPTION
When you build a base image for PHP7.0 you become a build error by build PHP ldap module:

-> Install PHP extension (14/20) ldap
-> Use core install
...
checking for unistd.h... (cached) yes
configure: error: Cannot find ldap libraries in /usr/lib.
BUILD FAILED!!!

This fix clear the issue.
