### PR TITLE
Feature/default pool via env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.49 (2021-04-12)
+
+**IMPROVEMENTS**
+* Make default pool pm configurable via environment variables
+
 # 1.1.48 (2020-01-19)
 **UPDATES**
 * PHP 7.3.13

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,14 @@ ENV PHP="php" \
     COMPOSER_ARGS="--no-dev" \
     COMPOSER_DUMP_ARGS="--optimize --classmap-authoritative --no-dev --apcu"
 
+# PHP-FPM DEFAULT POOL
+ENV FPM_PM="dynamic" \
+    FPM_PM_MAX_CHILDREN="50" \
+    FPM_PM_START_SERVERS="5" \
+    FPM_PM_MIN_SPARE_SERVERS="5" \
+    FPM_PM_MAX_SPARE_SERVERS="5" \
+    FPM_PM_MAX_REQUESTS="500"
+
 # SMTP
 # https://symfony.com/doc/current/reference/configuration/swiftmailer.html
 ENV ENABLE_SMTP="false" \

--- a/README.md
+++ b/README.md
@@ -290,6 +290,16 @@ use the [ini-env-var substitution feature](http://php.net/manual/en/configuratio
 | COMPOSER_ARGS                       | Additional `composer install` arguments, passed in `build > deps` subsection      |
 | COMPOSER_DUMP_ARGS                  | Args applied to the `composer autodump` command                                   |
 
+### PHP-FPM (Default Pool)
+
+| Name                                | Description                               |
+|-------------------------------------|-------------------------------------------|
+| FPM_PM			      | Process management type e.g dynamic    	  |
+| FPM_PM_MAX_CHILDREN                 | pm.max_children in default pool	       	  |
+| FPM_PM_START_SERVERS                | pm.start_servers in default pool       	  |
+| FPM_PM_MIN_SPARE_SERVERS            | pm.min_spare_servers in default pool   	  |
+| FPM_PM_MAX_SPARE_SERVERS            | pm.max_spare_servers in default pool   	  |
+| FPM_PM_MAX_REQUESTS                 | pm.max_requests in default pool	       	  |
 
 ### Mailing
 
@@ -321,7 +331,11 @@ The php-fpm configuration is designed to match a generic pattern - optimized to 
 per container. Normally you shouldn't be required to change the fpm configuration at all - if your container
 needs to handle more requests, launch another one and balance the traffic.substitute
 
-If you still need to extend the php-fpm config - the `start > phpfpm` subsection is prepared to launch different
+If you still need to extend the php-fpm config there are 2 options:
+
+1) Adjust the environment variables for the default pool e.g. `FPM_PM_MAX_CHILDREN`.
+
+2) The `start > phpfpm` subsection is prepared to launch different
 fpm pools. To launch e.g. a pool named `wordpress`, after you added the pools config to the container:
 `/entrypoint.sh start phpfpm wordpress`
 

--- a/docker/usr/local/etc/php-fpm.d/default.conf
+++ b/docker/usr/local/etc/php-fpm.d/default.conf
@@ -8,12 +8,13 @@ listen = 0.0.0.0:9000
 user = www-data
 group = www-data
 
-pm = dynamic
-pm.max_children = 50
-pm.start_servers = 5
-pm.min_spare_servers = 5
-pm.max_spare_servers = 5
-pm.max_requests = 500
+
+pm = ${FPM_PM}
+pm.max_children = ${FPM_PM_MAX_CHILDREN}
+pm.start_servers = ${FPM_PM_START_SERVERS}
+pm.min_spare_servers = ${FPM_PM_MIN_SPARE_SERVERS}
+pm.max_spare_servers = ${FPM_PM_MAX_SPARE_SERVERS}
+pm.max_requests = ${FPM_PM_MAX_REQUESTS}
 
 pm.status_path = /status
 


### PR DESCRIPTION
This will make the default phpfpm pool adjustable via environment variables.

I have tested it locally by:

```
docker run 6c419c9fd676 "php-fpm -tt"
docker run -e FPM_PM_MAX_CHILDREN=100 6c419c9fd676 "php-fpm -tt"
```