### PR TITLE
Fix GitHub actions workflows to be successfull

### DIFF
--- a/.github/workflows/build-and-release-image.yaml
+++ b/.github/workflows/build-and-release-image.yaml
@@ -26,4 +26,7 @@ jobs:
           sudo apt install -y coreutils gettext
 
       - name: Build and publish image
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: ./bin/ci.sh run

--- a/.github/workflows/build-and-release-image.yaml
+++ b/.github/workflows/build-and-release-image.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV ENABLE_GCP="${ENABLE_GCP:-0}" \
 # ssmtp: synchronouse mailer, very handy in CLI scripts on docker
 ENV PATH="${PATH}:${WORKDIR}/docker/bin" \
     BUILD_PACKAGES="ccache build-essential unzip zip" \
-    SYSTEM_PACKAGES="ssmtp busybox-static netcat vim less tree libtcmalloc-minimal4 git postgresql-client gettext nginx" \
+    SYSTEM_PACKAGES="ssmtp busybox-static netcat vim less tree libtcmalloc-minimal4 git postgresql-client gettext nginx apt-transport-https" \
     JESSIE_PACKAGE_MAP="libpng16-16:libpng12-0 libicu57:libicu52 libmagickwand-6.q16-3:libmagickwand-6.q16-2 libmagickcore-6.q16-3:libmagickcore-6.q16-2 npm:" \
     BUSTER_PACKAGE_MAP="libicu57:libicu63 libmagickwand-6.q16-3:libmagickwand-6.q16-6 libmagickcore-6.q16-3:libmagickcore-6.q16-6 ssmtp:msmtp" \
     ENABLE_NEWRELIC="false"
@@ -48,7 +48,7 @@ ENV NGINX_SITES_AVAILABLE="/etc/nginx/sites-available" \
 
 # NODEJS
 ENV ENABLE_NODEJS="true" \
-    NODEJS_VERSION="8" \
+    NODEJS_VERSION="14" \
     ENABLE_BOWER="true" \
     NPM="npm" \
     NPM_BUILD_PACKAGES="" \

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -5,8 +5,8 @@ WORKDIR=$(realpath $0 | xargs dirname | xargs dirname)
 
 export VERSION=$(cat $WORKDIR/VERSION)
 export IMAGE_NAME="claranet/php"
-FROM_IMAGE_TAGS="7.1.33-fpm-jessie 7.2.26-fpm-stretch 7.3.13-fpm-stretch"
-LATEST_IMAGE="7.3.13-fpm-stretch"
+FROM_IMAGE_TAGS="7.1.33-fpm-stretch 7.2.34-fpm-stretch 7.3.28-fpm-stretch"
+LATEST_IMAGE="7.3.28-fpm-stretch"
 
 # Based on $GITHUB_HEAD_REF which is set fot pull requests 
 # and $RELEASE_VERSION which holds either the branch name or tag

--- a/bin/image.sh
+++ b/bin/image.sh
@@ -13,11 +13,11 @@ IMAGE=${IMAGE:-"$IMAGE_NAME:$IMAGE_TAG"}
 
 test_image() {
     docker run --rm -t ${1} test
-    docker build --no-cache -t local/matomo:$IMAGE_TAG -f example/matomo/Dockerfile example/matomo/
+    envsubst '$IMAGE' < example/matomo/Dockerfile | docker build -t local/matomo:$IMAGE_TAG -f - example/matomo/
 }
 
 build_image() {
-    envsubst '$FROM_IMAGE' < Dockerfile | docker build --no-cache -t $* -f - ${WORKDIR}
+    envsubst '$FROM_IMAGE' < Dockerfile | docker build -t $* -f - ${WORKDIR}
 }
 
 

--- a/bin/image.sh
+++ b/bin/image.sh
@@ -13,11 +13,11 @@ IMAGE=${IMAGE:-"$IMAGE_NAME:$IMAGE_TAG"}
 
 test_image() {
     docker run --rm -t ${1} test
-    docker build -t local/matomo:$IMAGE_TAG -f example/matomo/Dockerfile example/matomo/
+    docker build --no-cache -t local/matomo:$IMAGE_TAG -f example/matomo/Dockerfile example/matomo/
 }
 
 build_image() {
-    envsubst '$FROM_IMAGE' < Dockerfile | docker build -t $* -f - ${WORKDIR}
+    envsubst '$FROM_IMAGE' < Dockerfile | docker build --no-cache -t $* -f - ${WORKDIR}
 }
 
 

--- a/docker/build.d/deps/350_nodejs.sh
+++ b/docker/build.d/deps/350_nodejs.sh
@@ -7,7 +7,13 @@ if ! is_true "$ENABLE_NODEJS"; then
 fi
 
 sectionText "Enable upstream nodejs debian repository"
+# The following line is for allowing to fetch apt-transport-https from buster-updates
+# As the requirement to install apt-transport-https comes from below nodejs bash
+# script we're not able to pin to a specific version of apt-transport-https to avoid this issue.
+sed -i '2,2s/buster/buster*/' /etc/apt/preferences.d/argon2-buster
 eatmydata curl -sL https://deb.nodesource.com/setup_${NODEJS_VERSION}.x | eatmydata bash - &>> $BUILD_LOG
+# Undo the above modifiaction to only allow this for this use-case
+sed -i '2,2s/buster*/buster/' /etc/apt/preferences.d/argon2-buster
 update_apt_cache --force
 install_packages --build nodejs npm
 

--- a/docker/build.d/deps/350_nodejs.sh
+++ b/docker/build.d/deps/350_nodejs.sh
@@ -7,13 +7,7 @@ if ! is_true "$ENABLE_NODEJS"; then
 fi
 
 sectionText "Enable upstream nodejs debian repository"
-# The following line is for allowing to fetch apt-transport-https from buster-updates
-# As the requirement to install apt-transport-https comes from below nodejs bash
-# script we're not able to pin to a specific version of apt-transport-https to avoid this issue.
-sed -i '2,2s/buster/buster*/' /etc/apt/preferences.d/argon2-buster
 eatmydata curl -sL https://deb.nodesource.com/setup_${NODEJS_VERSION}.x | eatmydata bash - &>> $BUILD_LOG
-# Undo the above modifiaction to only allow this for this use-case
-sed -i '2,2s/buster*/buster/' /etc/apt/preferences.d/argon2-buster
 update_apt_cache --force
 install_packages --build nodejs npm
 

--- a/example/matomo/Dockerfile
+++ b/example/matomo/Dockerfile
@@ -1,4 +1,4 @@
-FROM claranet/php:latest
+FROM ${IMAGE}
 
 ENV DOCUMENT_ROOT="${WORKDIR}" \
     COMPRESS_FILE_PATHS="js"


### PR DESCRIPTION
Currently the GitHub actions pipelines fail because of an issue inside of the docker images on installing NodeJS. This PR is updating to the latest patch updates of the php base images and fix this issue. The fix for this issue is by installing this package along with the system packages and more important adjustment on the example/matomo dockerfile which refered to the latest upstream image of this project. This lead to issues properly testing the image as the upstream image was pushed with a flaw.

Issue occurred during build of the image which made the pipeline fail: 
The issue occurring which made the pipelines fail was that the apt-transport-https package couldn't be installed properly.