### PR TITLE
Update PHP 8 flavour properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ set via environment variables and makes it easy to check external services (like
 
 * extends official docker php images
 * provides generic build and life cycle infrastructure for containerized PHP applications (well prepared for kubernetes)
-* shipped as PHP 7.1.x, 7.2.x and 7.3.x flavor
+* shipped as PHP 7.1.x, 7.2.x and 7.3.x 8.1.x flavor
 * there is a (build>base already run / build>base only prepared) flavor for each PHP version
-* general run concept: `docker run --rm -t claranet/php:1.1.58-php7.3.13 <main-section> [subsection] [subsection-args, ...]`
-* overview: `docker run --rm -t claranet/php:1.1.58-php7.3.13 help`
+* general run concept: `docker run --rm -t claranet/php:1.1.58-php8.1.7 <main-section> [subsection] [subsection-args, ...]`
+* overview: `docker run --rm -t claranet/php:1.1.58-php8.1.7 help`
 * supplied services
     - nginx
     - phpfpm
@@ -50,7 +50,7 @@ set via environment variables and makes it easy to check external services (like
 
 Build image locally:
 ```sh
-# generates local/claranet/php:1.1.58-php7.3.13
+# generates local/claranet/php:1.1.58-php8.1.7
 ./bin/image.sh build
 ```
 

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -5,8 +5,8 @@ WORKDIR=$(realpath $0 | xargs dirname | xargs dirname)
 
 export VERSION=$(cat $WORKDIR/VERSION)
 export IMAGE_NAME="claranet/php"
-FROM_IMAGE_TAGS="7.1.33-fpm-stretch 7.2.34-fpm-stretch 7.3.28-fpm-stretch"
-LATEST_IMAGE="7.3.28-fpm-stretch"
+FROM_IMAGE_TAGS="7.1.33-fpm-stretch 7.2.34-fpm-stretch 7.3.28-fpm-stretch 8.1.7-fpm-buster"
+LATEST_IMAGE="8.1.7-fpm-buster"
 
 # Based on $GITHUB_HEAD_REF which is set fot pull requests 
 # and $RELEASE_VERSION which holds either the branch name or tag


### PR DESCRIPTION
The PHP8 flavour was missing in the CI scripts to publish them to docker hub. I've added this now and also updated the documentation.